### PR TITLE
Build OSX binary with travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+os:
+  - linux
+  - osx
+
+
 language: c
 compiler:
         - gcc
@@ -7,15 +12,39 @@ notifications:
 
 sudo: required
 
+addons:
+  apt:
+    packages:
+      - autotools-dev
+      - autopoint
+      - libtool
+      - intltool
+      - libpng12-dev
+      - libexif-dev
+      - libtiff5-dev
+      - libjpeg-dev
+      - libxml2-dev
+      - libbz2-dev
+      - libpstoedit-dev
+      - libmagickcore-dev
+      - libfreetype6-dev
+
+
+# CAUTION: all the scripts run under set -e. So we always use || for os specific commands.
+
 before_install:
-        - sudo apt-get -qq update
-        - sudo apt-get install -y autotools-dev autopoint libtool intltool libpng12-dev libexif-dev libtiff5-dev libjpeg-dev libxml2-dev libbz2-dev libpstoedit-dev libmagickcore-dev libfreetype6-dev
+        - test "$TRAVIS_OS_NAME" != osx || brew update
+        - test "$TRAVIS_OS_NAME" != osx || brew install gettext intltool glib
+
 
 before_script:
+        - test "$TRAVIS_OS_NAME" != osx || export PATH="/usr/local/opt/gettext/bin:$PATH"
         - autoreconf -ivf
         - intltoolize --force
-        - ./configure
+        - test "$TRAVIS_OS_NAME" != osx || sh ./configure --without-magick --without-pstoedit
+        - test "$TRAVIS_OS_NAME" != linux || ./configure
 
 script:
         - make
-
+        - LD_LIBRARY_PATH=.libs ldd .libs/autotrace || true 
+        - ./autotrace -v

--- a/INSTALL_OSX.md
+++ b/INSTALL_OSX.md
@@ -1,0 +1,20 @@
+Build on OSX
+============
+
+On OSX, gettext gets installed into /usr/local/opt/gettext, so we need to add
+that to the path or autoreconf and intltoolize would fail due to missing 
+`autopoint`.
+
+This is a minimal make, without ImageMagic or pstoedit support.
+Which is probably a good idea anyway, as long as we have known security issues 
+when using pstoedit.
+
+```
+export PATH="/usr/local/opt/gettext/bin:$PATH"
+brew install intltool
+autoreconf -ivf
+intltoolize --force
+sh ./configure --without-magick --without-pstoedit
+make
+```
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/jnweiger/autotrace.svg?branch=future)](https://travis-ci.org/jnweiger/autotrace)
+
+
 AutoTrace
 =========
 


### PR DESCRIPTION
.. as discussed in https://github.com/autotrace/autotrace/issues/4

ATTENTION: Please change the code in the README.md to point to your own travis builds...
I did not find a portable way to do that.